### PR TITLE
Support for Julia 0.4 by re-exporting Base objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - linux
   - osx
 julia:
+  - 0.4
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # LegacyStrings
 
-[![Build Status](https://travis-ci.org/JuliaArchive/LegacyStrings.jl.svg?branch=master)](https://travis-ci.org/JuliaArchive/LegacyStrings.jl)
+[![Travis CI Build Status](https://travis-ci.org/JuliaArchive/LegacyStrings.jl.svg?branch=master)](https://travis-ci.org/JuliaArchive/LegacyStrings.jl)
+[![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/ib52329urgg62jai?svg=true)](https://ci.appveyor.com/project/nalimilan/legacystrings-jl)
+
+[![Julia 0.4 Status](http://pkg.julialang.org/badges/LegacyStrings_0.4.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.4)
+[![Julia 0.5 Status](http://pkg.julialang.org/badges/LegacyStrings_0.5.svg)](http://pkg.julialang.org/?pkg=LegacyStrings&ver=0.5)

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
-julia 0.5.0-
+julia 0.4
+Compat 0.8.4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 environment:
   matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -40,40 +40,43 @@ import Base:
     uppercase,
     write
 
-immutable ASCIIString <: DirectIndexString
-    data::Array{UInt8,1}
-end
-
-immutable UTF8String <: AbstractString
-    data::Vector{UInt8}
-end
-
-immutable UTF16String <: AbstractString
-    data::Vector{UInt16} # includes 16-bit NULL termination after string chars
-    function UTF16String(data::Vector{UInt16})
-        if length(data) < 1 || data[end] != 0
-            throw(UnicodeError(UTF_ERR_NULL_16_TERMINATE, 0, 0))
+    if VERSION >= v"0.5.0-"
+        immutable ASCIIString <: DirectIndexString
+            data::Array{UInt8,1}
         end
-        new(data)
-    end
-end
 
-immutable UTF32String <: DirectIndexString
-    data::Vector{UInt32} # includes 32-bit NULL termination after string chars
-    function UTF32String(data::Vector{UInt32})
-        if length(data) < 1 || data[end] != 0
-            throw(UnicodeError(UTF_ERR_NULL_32_TERMINATE, 0, 0))
+        immutable UTF8String <: AbstractString
+            data::Vector{UInt8}
         end
-        new(data)
+
+        immutable UTF16String <: AbstractString
+            data::Vector{UInt16} # includes 16-bit NULL termination after string chars
+            function UTF16String(data::Vector{UInt16})
+                if length(data) < 1 || data[end] != 0
+                    throw(UnicodeError(UTF_ERR_NULL_16_TERMINATE, 0, 0))
+                end
+                new(data)
+            end
+        end
+
+        immutable UTF32String <: DirectIndexString
+            data::Vector{UInt32} # includes 32-bit NULL termination after string chars
+            function UTF32String(data::Vector{UInt32})
+                if length(data) < 1 || data[end] != 0
+                    throw(UnicodeError(UTF_ERR_NULL_32_TERMINATE, 0, 0))
+                end
+                new(data)
+            end
+        end
+
+        typealias ByteString Union{ASCIIString,UTF8String}
+
+        include("support.jl")
+        include("ascii.jl")
+        include("utf8.jl")
+        include("utf16.jl")
+        include("utf32.jl")
+    else
+        using Base: UTF_ERR_SHORT, checkstring
     end
-end
-
-typealias ByteString Union{ASCIIString,UTF8String}
-
-include("support.jl")
-include("ascii.jl")
-include("utf8.jl")
-include("utf16.jl")
-include("utf32.jl")
-
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
 using Base.Test
+using Compat: view
 importall LegacyStrings
 import LegacyStrings:
     ascii,
@@ -21,7 +22,11 @@ badstring32  = UInt32['a']
 # Unicode errors
 let io = IOBuffer()
     show(io, UnicodeError(UTF_ERR_SHORT, 1, 10))
-    check = "UnicodeError: invalid UTF-8 sequence starting at index 1 (0xa missing one or more continuation bytes)"
+    if VERSION >= v"0.5.0-dev+1956"
+        check = "UnicodeError: invalid UTF-8 sequence starting at index 1 (0xa missing one or more continuation bytes)"
+    else
+        check = "UnicodeError: invalid UTF-8 sequence starting at index 1 (0xa) missing one or more continuation bytes)"
+    end
     @test takebuf_string(io) == check
 end
 


### PR DESCRIPTION
The package needs to work on 0.4 so that packages depending on it
can support it (conditional dependencies do not exist yet).