### PR TITLE
Enable precompilation

### DIFF
--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -1,5 +1,7 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
+VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+
 module LegacyStrings
 
 export

--- a/src/LegacyStrings.jl
+++ b/src/LegacyStrings.jl
@@ -1,6 +1,6 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
 
-VERSION >= v"0.4.0-dev+6521" && __precompile__(true)
+__precompile__(true)
 
 module LegacyStrings
 


### PR DESCRIPTION
Looks like Feather.jl is failing to precompile since it depends on a package that depends on this, and this doesn't precompile. (Or at least I think that's what's happening)