### PR TITLE
Remove string(::Union{ByteString,Char}...) method

### DIFF
--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -157,36 +157,6 @@ function string(a::ByteString...)
     UTF8String(data)
 end
 
-function string(a::Union{ByteString,Char}...)
-    s = Vector{UInt8}(0)
-    for d in a
-        if isa(d,Char)
-            c = UInt32(d::Char)
-            if c < 0x80
-                push!(s, c%UInt8)
-            elseif c < 0x800
-                push!(s, (( c >> 6          ) | 0xC0)%UInt8)
-                push!(s, (( c        & 0x3F ) | 0x80)%UInt8)
-            elseif c < 0x10000
-                push!(s, (( c >> 12         ) | 0xE0)%UInt8)
-                push!(s, (((c >> 6)  & 0x3F ) | 0x80)%UInt8)
-                push!(s, (( c        & 0x3F ) | 0x80)%UInt8)
-            elseif c < 0x110000
-                push!(s, (( c >> 18         ) | 0xF0)%UInt8)
-                push!(s, (((c >> 12) & 0x3F ) | 0x80)%UInt8)
-                push!(s, (((c >> 6)  & 0x3F ) | 0x80)%UInt8)
-                push!(s, (( c        & 0x3F ) | 0x80)%UInt8)
-            else
-                # '\ufffd'
-                push!(s, 0xef); push!(s, 0xbf); push!(s, 0xbd)
-            end
-        else
-            append!(s,d.data)
-        end
-    end
-    UTF8String(s)
-end
-
 function reverse(s::UTF8String)
     dat = s.data
     n = length(dat)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -235,6 +235,9 @@ end
 # Specifically check UTF-8 string whose lead byte is same as a surrogate
 @test convert(UTF8String,b"\xed\x9f\xbf") == "\ud7ff"
 
+# issue #8
+@test !isempty(methods(string, Tuple{Char}))
+
 ## UTF-16 tests
 
 u8 = "\U10ffff\U1d565\U1d7f6\U00066\U2008a"


### PR DESCRIPTION
Given how long #8 has been dormant, I propose this simple fix. For `string(::ByteString...)`, the dedicated method above the deleted one is used. For `string(::Char...)` the method from `Base` is used (that previously was the cause of the ambiguity). For a mixture of `ByteString` and `Char` arguments, the `string(::Any...)` fallback is used, which should give the correct result, but might be a bit slower (though I haven't checked this).