### PR TITLE
Fix test failure with ReinterpretArray

### DIFF
--- a/src/utf32.jl
+++ b/src/utf32.jl
@@ -89,7 +89,7 @@ function convert(::Type{UTF32String}, str::UTF16String)
     # get number of words to create
     len, flags, num4byte = unsafe_checkstring(dat, 1, len>>>1)
     # No surrogate pairs, do optimized copy
-    (flags & UTF_UNICODE4) == 0 && @inbounds return UTF32String(copy!(Vector{Char}(len), dat))
+    (flags & UTF_UNICODE4) == 0 && @inbounds return UTF32String(copy!(Vector{UInt32}(len), dat))
     local ch::UInt32
     buf = Vector{UInt32}(len)
     out = 0


### PR DESCRIPTION
`next(x, endof(x))` is not generally valid with AbstractVectors even though
it works for Vector. This fixes a test failure on Julia 0.7.

The `UTF32String(::Vector{Char})` constructor added a `\0` char at the end of the string because it used `reinterpret(UInt32, ...)`, which did not dispatch to the inner constructor directly as it used to do on 0.6.